### PR TITLE
Sets Error Message whenever an execption is thrown

### DIFF
--- a/src/FixAcceptorStartWorker.cpp
+++ b/src/FixAcceptorStartWorker.cpp
@@ -23,6 +23,7 @@ void FixAcceptorStartWorker::Execute () {
 	try {
 		acceptor->start();
 	} catch(FIX::ConfigError& e) {
+    this->SetErrorMessage("Failed to start FIX Acceptor");
 		//handle this exception
 	}
 }

--- a/src/FixAcceptorStartWorker.cpp
+++ b/src/FixAcceptorStartWorker.cpp
@@ -20,26 +20,26 @@ using namespace node;
 // here, so everything we need for input and output
 // should go on `this`.
 void FixAcceptorStartWorker::Execute () {
-	try {
-		acceptor->start();
-	} catch(FIX::ConfigError& e) {
+  try {
+    acceptor->start();
+  } catch(FIX::ConfigError& e) {
     this->SetErrorMessage("Failed to start FIX Acceptor");
-		//handle this exception
-	}
+    //handle this exception
+  }
 }
 
 // Executed when the async work is complete
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixAcceptorStartWorker::HandleOKCallback () {
-	Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
     v8::Local<v8::Function> fn = callback->GetFunction();
-	if(!(fn->IsUndefined() || fn->IsNull())) {
-		Local<Value> argv[] = {
-			Nan::Null()
-		};
+  if(!(fn->IsUndefined() || fn->IsNull())) {
+    Local<Value> argv[] = {
+      Nan::Null()
+    };
 
-		callback->Call(1, argv);
-	}
+    callback->Call(1, argv);
+  }
 }

--- a/src/FixAcceptorStopWorker.cpp
+++ b/src/FixAcceptorStopWorker.cpp
@@ -20,26 +20,26 @@ using namespace node;
 // here, so everything we need for input and output
 // should go on `this`.
 void FixAcceptorStopWorker::Execute () {
-	try {
-		acceptor->stop();
-	} catch(FIX::ConfigError& e) {
+  try {
+    acceptor->stop();
+  } catch(FIX::ConfigError& e) {
     this->SetErrorMessage("Failed to stop FIX Acceptor");
-		//handle this exception
-	}
+    //handle this exception
+  }
 }
 
 // Executed when the async work is complete
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixAcceptorStopWorker::HandleOKCallback () {
-	Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
     v8::Local<v8::Function> fn = callback->GetFunction();
-	if(!(fn->IsUndefined() || fn->IsNull())) {
-		Local<Value> argv[] = {
-			Nan::Null()
-		};
+  if(!(fn->IsUndefined() || fn->IsNull())) {
+    Local<Value> argv[] = {
+      Nan::Null()
+    };
 
-		callback->Call(1, argv);
-	}
+    callback->Call(1, argv);
+  }
 }

--- a/src/FixAcceptorStopWorker.cpp
+++ b/src/FixAcceptorStopWorker.cpp
@@ -23,6 +23,7 @@ void FixAcceptorStopWorker::Execute () {
 	try {
 		acceptor->stop();
 	} catch(FIX::ConfigError& e) {
+    this->SetErrorMessage("Failed to stop FIX Acceptor");
 		//handle this exception
 	}
 }

--- a/src/FixInitiatorStartWorker.cpp
+++ b/src/FixInitiatorStartWorker.cpp
@@ -20,26 +20,26 @@ using namespace node;
 // here, so everything we need for input and output
 // should go on `this`.
 void FixInitiatorStartWorker::Execute () {
-	try {
-		initiator->start();
-	} catch(FIX::ConfigError& e) {
+  try {
+    initiator->start();
+  } catch(FIX::ConfigError& e) {
     this->SetErrorMessage("Failed to start FIX Initiator");
-		//handle this exception
-	}
+    //handle this exception
+  }
 }
 
 // Executed when the async work is complete
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixInitiatorStartWorker::HandleOKCallback () {
-	Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
     v8::Local<v8::Function> fn = callback->GetFunction();
-	if(!(fn->IsUndefined() || fn->IsNull())) {
-		Local<Value> argv[] = {
-			Nan::Null()
-		};
+  if(!(fn->IsUndefined() || fn->IsNull())) {
+    Local<Value> argv[] = {
+      Nan::Null()
+    };
 
-		callback->Call(1, argv);
-	}
+    callback->Call(1, argv);
+  }
 }

--- a/src/FixInitiatorStartWorker.cpp
+++ b/src/FixInitiatorStartWorker.cpp
@@ -23,6 +23,7 @@ void FixInitiatorStartWorker::Execute () {
 	try {
 		initiator->start();
 	} catch(FIX::ConfigError& e) {
+    this->SetErrorMessage("Failed to start FIX Initiator");
 		//handle this exception
 	}
 }

--- a/src/FixInitiatorStopWorker.cpp
+++ b/src/FixInitiatorStopWorker.cpp
@@ -20,26 +20,26 @@ using namespace node;
 // here, so everything we need for input and output
 // should go on `this`.
 void FixInitiatorStopWorker::Execute () {
-	try {
-		initiator->stop();
-	} catch(FIX::ConfigError& e) {
+  try {
+    initiator->stop();
+  } catch(FIX::ConfigError& e) {
     this->SetErrorMessage("Failed to stop FIX Initiator");
-		//handle this exception
-	}
+    //handle this exception
+  }
 }
 
 // Executed when the async work is complete
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixInitiatorStopWorker::HandleOKCallback () {
-	Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
     v8::Local<v8::Function> fn = callback->GetFunction();
-	if(!(fn->IsUndefined() || fn->IsNull())) {
-		Local<Value> argv[] = {
-			Nan::Null()
-		};
+  if(!(fn->IsUndefined() || fn->IsNull())) {
+    Local<Value> argv[] = {
+      Nan::Null()
+    };
 
-		callback->Call(1, argv);
-	}
+    callback->Call(1, argv);
+  }
 }

--- a/src/FixInitiatorStopWorker.cpp
+++ b/src/FixInitiatorStopWorker.cpp
@@ -23,6 +23,7 @@ void FixInitiatorStopWorker::Execute () {
 	try {
 		initiator->stop();
 	} catch(FIX::ConfigError& e) {
+    this->SetErrorMessage("Failed to stop FIX Initiator");
 		//handle this exception
 	}
 }

--- a/src/FixSendWorker.cpp
+++ b/src/FixSendWorker.cpp
@@ -21,26 +21,26 @@ using namespace node;
 // here, so everything we need for input and output
 // should go on `this`.
 void FixSendWorker::Execute () {
-	try {
-		FIX::Session::sendToTarget(*message);
-	} catch(FIX::SessionNotFound& e) {
+  try {
+    FIX::Session::sendToTarget(*message);
+  } catch(FIX::SessionNotFound& e) {
     std::cout << "*** Session not found!" << std::endl;
     this->SetErrorMessage("Failed to send FIX Message");
-	}
+  }
 }
 
 // Executed when the async work is complete
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixSendWorker::HandleOKCallback () {
-	Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
     v8::Local<v8::Function> fn = callback->GetFunction();
-	if(!(fn->IsUndefined() || fn->IsNull())) {
-		Local<Value> argv[] = {
-			Nan::Null()
-		};
+  if(!(fn->IsUndefined() || fn->IsNull())) {
+    Local<Value> argv[] = {
+      Nan::Null()
+    };
 
-		callback->Call(1, argv);
-	}
+    callback->Call(1, argv);
+  }
 }

--- a/src/FixSendWorker.cpp
+++ b/src/FixSendWorker.cpp
@@ -24,7 +24,8 @@ void FixSendWorker::Execute () {
 	try {
 		FIX::Session::sendToTarget(*message);
 	} catch(FIX::SessionNotFound& e) {
-		std::cout << "*** Session not found!" << std::endl;
+    std::cout << "*** Session not found!" << std::endl;
+    this->SetErrorMessage("Failed to send FIX Message");
 	}
 }
 


### PR DESCRIPTION
SetErrorMessage being populated is what triggers the error callback. These Execute function catching exceptions and continuing silently seem to be where the Error Message should be set. Relevant [SO](https://stackoverflow.com/questions/57438481/how-are-function-failures-propagated-for-nodejs-wrapped-c-code/57468045#57468045)